### PR TITLE
fix handling of wildcard routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class Server {
           for(let route of this.#stack) {
             if(route.fast_star || route.regexp != null && (m = route.match(u.pathname))){
                 matched_route = route;
-                req.params = m.params;
+                req.params = m?m.params:null;
                 break;
             }
           }


### PR DESCRIPTION
this should fix an issue where an error would be thrown when handling any wildcard route, due to them not having a `match` method