### PR TITLE
feat: add middleware support through `app.use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ s is an int
 
 `res.redirect(url)` Redirect the client to the specified url.
 
+### Middleware
+
+A middleware registered through `app.use` will be executed before every route handler. If a path is given as the first argument, only that path will be affected.
+
+```javascript
+app.use((req, res, next) => {
+    console.log(`Route ${req.path} was called`);
+});
+app.use('/foo', (req, res, next) => {
+    console.log(`Foo route was called`);
+});
+```
+
 ## Example Server
 ```javascript
 const fs = require('fs');

--- a/example.js
+++ b/example.js
@@ -8,6 +8,11 @@ const options = {
 
 const app = gemini(options);
 
+app.use((req, res, next) => {
+    console.log("Handling path", req.path);
+    next();
+});
+
 app.on('/', (req, res) => {
   res.file('test.gemini');
 });


### PR DESCRIPTION
Middlewares mounted with `app.use` will be executed on every route that matches the first argument. If no argument is given, all routes will match.