### PR TITLE
Handling ECONNRESET error

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ class Server {
 		    rejectUnauthorized: false
       }, (conn) => {
         conn.setEncoding('utf8');
+	conn.on('error', (err) => {
+	  if(err && err.code === "ECONNRESET") return;
+	  console.error(err);
+	});
         conn.on('data', async (data) => {
           let u = url.parse(data);
           if(u.protocol !== 'gemini' && u.protocol !== 'gemini:'){


### PR DESCRIPTION
These errors commonly appear when the other side of the TCP conversation closes/kills the connection.

I was visiting my Gemini page a few hours ago and I was wondering why the status page said it restarted, and I ran into said error, which was specific to the browser I was using.

And well, I couldn't just allow the process to restart when they kill their TCP connection.

No idea how you want to handle other TCP errors, but it is best to ignore the ECONNRESET error since they appear more from the connection of the other user than from something to do with the server/process.