### PR TITLE
Match middleware paths like express

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Server {
 
         const isMatch = (route) =>
           route.fast_star ||
-          route.regexp != null && (m = route.match(u.pathname));
+          route.regexp != null && (m = route.match(u.pathname)) || route.regexp.exec(u.pathname);
 
         const middlewares = this._middlewares.filter(isMatch);
         const middlewareHandlers = middlewares.flatMap(({ handlers }) =>
@@ -108,6 +108,7 @@ class Server {
       regexp: path === "*" ? null : pathToRegexp(path, [], {
         sensitive: true,
         strict: false,
+        end: true
       }),
       match: path === "*"
         ? function () {
@@ -131,6 +132,7 @@ class Server {
         ? pathToRegexp(path, [], {
           sensitive: true,
           strict: false,
+          end: false
         })
         : null,
       match: !hasPath || path === "*"

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Server {
 
         const isMatch = (route) =>
           route.fast_star ||
-          route.regexp != null && (m = route.match(u.pathname)) || route.regexp.exec(u.pathname);
+          route.regexp != null && (m = route.match(u.pathname));
 
         const middlewares = this._middlewares.filter(isMatch);
         const middlewareHandlers = middlewares.flatMap(({ handlers }) =>
@@ -137,7 +137,7 @@ class Server {
         : null,
       match: !hasPath || path === "*"
         ? () => true
-        : match(path, { encode: encodeURI, decode: decodeURIComponent }),
+        : match(path, { encode: encodeURI, decode: decodeURIComponent, end: false }),
       handlers,
       fast_star: !hasPath || path === "*",
     });

--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ function requireCert(req, res, next) {
 
 module.exports = ({ key, cert }) => {
   if (!key || !cert) {
-    throw "Must specify key and cert";
+    throw new Error("Must specify key and cert");
   }
   return new Server(key, cert);
 };


### PR DESCRIPTION
Middleware mounted with .use matched the full URL and therefore couldn't be used like express middleware which matches only the beginning of the string.

For example:
```app.use('/secure', ...)```
would only be applied to an URL which matches the exact path 'secure' unlike specified in http://expressjs.com/en/4x/api.html#path-examples.