### PR TITLE
fix redirectOnDirectory

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -55,7 +55,7 @@ export function serveStatic(basePath: string, opts?: serveStaticOptions) : middl
     try {
       let stat = await fs.stat(fullPath);
       if (stat.isDirectory()) {
-        if (!filePath.endsWith('/')) {
+        if (!req.path?.endsWith('/')) {
           if (options.redirectOnDirectory) {
             res.redirect(req.path + '/');
             return;


### PR DESCRIPTION
No redirects were happening when browsing a static folder without a trailing backslash, despite the flag. (gemini://site/staticFolder for example, wouldn't redirect to /staticFolder/). This broke relative links