### PR TITLE
Find index ext

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -55,7 +55,7 @@ export function serveStatic(basePath: string, opts?: serveStaticOptions) : middl
     try {
       let stat = await fs.stat(fullPath);
       if (stat.isDirectory()) {
-        if (!filePath.endsWith('/')) {
+        if (!req.path?.endsWith('/')) {
           if (options.redirectOnDirectory) {
             res.redirect(req.path + '/');
             return;

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -55,7 +55,7 @@ export function serveStatic(basePath: string, opts?: serveStaticOptions) : middl
     try {
       let stat = await fs.stat(fullPath);
       if (stat.isDirectory()) {
-        if (!req.path?.endsWith('/')) {
+        if (!filePath.endsWith('/')) {
           if (options.redirectOnDirectory) {
             res.redirect(req.path + '/');
             return;

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -64,14 +64,16 @@ export function serveStatic(basePath: string, opts?: serveStaticOptions) : middl
           }
         }
         if (options.index) {
-          let extension = options.indexExtensions.findIndex(async function(ext){
+          let extension = 0;
+          for(let i = 0; i < options.indexExtensions.length; i++) {
             try {
-              await fs.access(fullPath + 'index' + ext);
-              return true;
-            } catch {
-              return false;
+              let file = fullPath + 'index' + options.indexExtensions[i];
+              await fs.access(file);
+              extension = i;
+              break;
+            } catch(ex) {
             }
-          });
+          }
           if (extension !== -1) {
             res.file(fullPath + 'index' + options.indexExtensions[extension]);
             return;


### PR DESCRIPTION
`.findIndex` just doesn't accept async functions ([AFAIK](https://stackoverflow.com/questions/55601062/using-an-async-function-in-array-find)), so I changed that logic to a less elegant, but still functional, `for` loop.