### PR TITLE
Find all extensions.

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -64,7 +64,7 @@ export function serveStatic(basePath: string, opts?: serveStaticOptions) : middl
           }
         }
         if (options.index) {
-          let extension = 0;
+          let extension = -1;
           for(let i = 0; i < options.indexExtensions.length; i++) {
             try {
               let file = fullPath + 'index' + options.indexExtensions[i];

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -64,14 +64,16 @@ export function serveStatic(basePath: string, opts?: serveStaticOptions) : middl
           }
         }
         if (options.index) {
-          let extension = options.indexExtensions.findIndex(async function(ext){
+          let extension = 0;
+          for(let i = 0; i < options.indexExtensions.length; i++) {
             try {
-              await fs.access(fullPath + 'index' + ext);
-              return true;
-            } catch {
-              return false;
+              let file = fullPath + 'index' + options.indexExtensions[i];
+              await fs.access(file);
+              extension = i;
+              break;
+            } catch(ex) {
             }
-          });
+          }
           if (extension !== -1) {
             res.file(fullPath + 'index' + options.indexExtensions[extension]);
             return;


### PR DESCRIPTION
`.findIndex` just doesn't accept async functions ([AFAIK](https://stackoverflow.com/questions/55601062/using-an-async-function-in-array-find)), so I changed that logic to a less elegant, but still functional, `for` loop.

Any async function as findIndex's parameter appears to just return 0.